### PR TITLE
Add support for Mojlicious 6

### DIFF
--- a/Changes
+++ b/Changes
@@ -15,3 +15,7 @@ Revision history for Mojolicious::Plugin::ValidateTiny
         
 0.12
         Added support for parameters with multiple values        
+
+0.13 
+        Added support for latest Mojolicious 6. 
+            - params no longer gives us a list back

--- a/lib/Mojolicious/Plugin/ValidateTiny.pm
+++ b/lib/Mojolicious/Plugin/ValidateTiny.pm
@@ -34,10 +34,10 @@ sub register {
             $rules->{fields} ||= [];
 
             # Validate GET+POST parameters by default
-            $params ||= { map {
-                my @values = $c->param($_);
-                $_ => ( @values > 1 ? \@values : ( $values[0] // undef ) ); 
-            } $c->param };
+            $params ||= $c->req->params->to_hash();
+
+            #Latest mojolicious has an issue in that it doesn't include route supplied parameters so we need to hack that in.
+            $params = { %{$params},  %{$c->stash->{'mojo.captures'}} };
             
             # Autofill fields
             if ( $conf->{autofields} ) {


### PR DESCRIPTION
Hello, it looks like the latest Mojolicious has several breaking changes.

1. $controller->param will no longer return a list.
2. There is no mechanism through the controller from which you can get a full list of all parameters.

To work around this we do the following.
1. Get a hash of all the parameters from the Mojolicious::Parameters object which hangs off the request object.
2. Then merge any missing parameters in that are supplied from the routes /some_controller/:some_parameter as an example.

I have tried to make this change to retain compatibility with pre-v6 Mojo too.