### PR TITLE
Support older versions of Validate::Tiny

### DIFF
--- a/Changes
+++ b/Changes
@@ -21,3 +21,8 @@ Revision history for Mojolicious::Plugin::ValidateTiny
             - params no longer gives us a list back
 0.15
         Fix compatibility with the latest version of Validate::Tiny
+
+0.16
+        Maintain compatability with older versions of Validate::Tiny,
+        useful for breaking the link between Validate::Tiny and Mojolicious 
+        both forcing you to update each other        

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -12,7 +12,7 @@ WriteMakefile(
     MIN_PERL_VERSION => 5.010,
     PREREQ_PM    => {
         'Mojolicious'    => 6.00,
-        'Validate::Tiny' => 1.501
+        'Validate::Tiny' => 0.984
     },
     META_MERGE   => {
         resources => {

--- a/lib/Mojolicious/Plugin/ValidateTiny.pm
+++ b/lib/Mojolicious/Plugin/ValidateTiny.pm
@@ -5,7 +5,7 @@ use v5.10;
 use strict;
 use warnings;
 use Carp qw/croak/;
-use Validate::Tiny 1.501;
+use Validate::Tiny;
 no if $] >= 5.017011, warnings => 'experimental::smartmatch';
 
 our $VERSION = '0.16';

--- a/lib/Mojolicious/Plugin/ValidateTiny.pm
+++ b/lib/Mojolicious/Plugin/ValidateTiny.pm
@@ -8,7 +8,7 @@ use Carp qw/croak/;
 use Validate::Tiny 1.501;
 no if $] >= 5.017011, warnings => 'experimental::smartmatch';
 
-our $VERSION = '0.15';
+our $VERSION = '0.16';
 
 sub register {
     my ( $self, $app, $conf ) = @_;
@@ -77,8 +77,15 @@ sub register {
                 }
             }
 
-            # Do validation
-            my $result = Validate::Tiny->check( $params, $rules );
+            # Do validation, Validate::Tiny made a breaking change and we need to support old and new users
+            my $result; 
+            if(Validate::Tiny->can('check')) {
+                $result = Validate::Tiny->check( $params, $rules );
+            }
+            else { # Fall back for old Validate::Tiny version
+                $result = Validate::Tiny->new( $params, $rules );
+            }
+            
             $c->stash( 'validate_tiny.result' => $result );
 
             if ( $result->success ) {


### PR DESCRIPTION
The only real difference with the recent Validate::Tiny change was moving from using ->new to ->check.

Because of this it would be trivial for us to support old and new for the time being.

As it stands users could end up in the situation where an update to Mojolicious would enforce a Validate::Tiny update, or a Validate::Tiny update enforce a Mojolicious update via this module.

