### PR TITLE
fix example in SYNOPSIS section of documentation

### DIFF
--- a/lib/Mojolicious/Plugin/ValidateTiny.pm
+++ b/lib/Mojolicious/Plugin/ValidateTiny.pm
@@ -223,10 +223,10 @@ Mojolicious::Plugin::ValidateTiny - Lightweight validator for Mojolicious
     __DATA__
 
     @@ user.html.ep
-    %= if (validator_has_errors) {
+    % if (validator_has_errors) {
         <div class="error">Please, correct the errors below.</div>
     % }
-    %= form_for 'user' => begin
+    % form_for 'user' => begin
         <label for="username">Username</label><br />
         <%= input_tag 'username' %><br />
         <%= validator_error 'username' %><br />


### PR DESCRIPTION
the template "user.html.ep" in the SYNOPSIS example fires the error:

   syntax error at template ... near "+  if"