### PR TITLE
fix example in SYNOPSIS section of documentation

### DIFF
--- a/lib/Mojolicious/Plugin/ValidateTiny.pm
+++ b/lib/Mojolicious/Plugin/ValidateTiny.pm
@@ -302,7 +302,7 @@ Check if there are any errors.
         $self->render_text( $self->validator_any_error );
     }
 
-    %= if (validator_has_errors) {
+    % if (validator_has_errors) {
         <div class="error">Please, correct the errors below.</div>
     % }
 

--- a/lib/Mojolicious/Plugin/ValidateTiny.pm
+++ b/lib/Mojolicious/Plugin/ValidateTiny.pm
@@ -223,7 +223,7 @@ Mojolicious::Plugin::ValidateTiny - Lightweight validator for Mojolicious
     __DATA__
 
     @@ user.html.ep
-    %= if (validator_has_errors) {
+    % if (validator_has_errors) {
         <div class="error">Please, correct the errors below.</div>
     % }
     %= form_for 'user' => begin


### PR DESCRIPTION
the template "user.html.ep" in the SYNOPSIS example fires the error:

   syntax error at template ... near "+  if"